### PR TITLE
Missing hf_transfer lib @ dev setup

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,3 +11,4 @@ python-dotenv
 ruff
 sphinx
 twine
+hf_transfer


### PR DESCRIPTION
# Missing package

## PR description

I tried to run the pipeline in the conda dev setup, and noticed the hf_transfer package is missing.

