### PR TITLE
Disable `hf_transfer` usage when downloading semantic segmentation model.

### DIFF
--- a/src/iris/nodes/segmentation/onnx_multilabel_segmentation.py
+++ b/src/iris/nodes/segmentation/onnx_multilabel_segmentation.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, List, Literal, Tuple
 
 import numpy as np
@@ -41,6 +42,7 @@ class ONNXMultilabelSegmentation(MultilabelSemanticSegmentationInterface):
             input_num_channels (Literal[1, 3], optional): Neural Network input image number of channels. Defaults to 3.
             callbacks (List[Callback], optional): List of algorithm callbacks. Defaults to [].
         """
+        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
         model_path = hf_hub_download(
             repo_id=MultilabelSemanticSegmentationInterface.HUGGING_FACE_REPO_ID,
             cache_dir=MultilabelSemanticSegmentationInterface.MODEL_CACHE_DIR,

--- a/src/iris/nodes/segmentation/tensorrt_multilabel_segmentation.py
+++ b/src/iris/nodes/segmentation/tensorrt_multilabel_segmentation.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Literal, Tuple
 
 import numpy as np
@@ -71,6 +72,7 @@ class TensorRTMultilabelSegmentation(MultilabelSemanticSegmentationInterface):
             model_name (str, optional): Name of the ONNX model stored in HuggingFace repo. Defaults to "iris_semseg_upp_scse_mobilenetv2.engine".
             input_num_channels (Literal[1, 3]): Model input image number of channels. Defaults to 3.
         """
+        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
         model_path = hf_hub_download(
             repo_id=MultilabelSemanticSegmentationInterface.HUGGING_FACE_REPO_ID,
             cache_dir=MultilabelSemanticSegmentationInterface.MODEL_CACHE_DIR,


### PR DESCRIPTION
# Disable `hf_transfer` usage when downloading semantic segmentation model.

## PR description

Disable `hf_transfer` usage when downloading semantic segmentation model.

## Type
<!-- Check a proper type with an 'x' ([x]). -->

- [x] Feature
- [x] Refactoring

## Checklist
<!-- Please make sure you did all pre review requesting steps and check all with an 'x' ([x]). -->

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
