### PR TITLE
Bump PyCUDA version to 2024.1

### DIFF
--- a/requirements/orb.txt
+++ b/requirements/orb.txt
@@ -1,2 +1,2 @@
-pycuda>=2021.1
+pycuda>=2024.1
 tensorrt>=8.5.2.2


### PR DESCRIPTION
# Bump PyCUDA version to 2024.1

## PR description

We need to bump the PyCUDA on the Orb for compatibility reasons.

## Type

- [ ] Feature
- [ ] Refactoring
- [x] Bugfix
- [ ] DevOps
- [ ] Testing

## Checklist

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
