### PR TITLE
finetuning P2I validator errors into dilation, constriction and offcenter

### DIFF
--- a/src/iris/io/errors.py
+++ b/src/iris/io/errors.py
@@ -45,6 +45,20 @@ class PupilIrisPropertyEstimationError(Exception):
 
     pass
 
+class Pupil2IrisValidatorError_Dilation(Exception):
+    """IsMaskGoodValidator error class."""
+
+    pass
+
+class Pupil2IrisValidatorError_Constriction(Exception):
+    """IsMaskGoodValidator error class."""
+
+    pass
+
+class Pupil2IrisValidatorError_Offcenter(Exception):
+    """IsMaskGoodValidator error class."""
+
+    pass
 
 class GeometryEstimationError(Exception):
     """GeometryEstimation module Error class."""
@@ -122,3 +136,4 @@ class IRISPipelineError(Exception):
     """IRIS Pipeline module Error class."""
 
     pass
+

--- a/src/iris/io/errors.py
+++ b/src/iris/io/errors.py
@@ -45,18 +45,18 @@ class PupilIrisPropertyEstimationError(Exception):
 
     pass
 
-class Pupil2IrisValidatorError_Dilation(Exception):
-    """IsMaskGoodValidator error class."""
+class Pupil2IrisValidatorErrorDilation(Exception):
+    """Pupil2IrisValidatorErrorDilation error class."""
 
     pass
 
-class Pupil2IrisValidatorError_Constriction(Exception):
-    """IsMaskGoodValidator error class."""
+class Pupil2IrisValidatorErrorConstriction(Exception):
+    """Pupil2IrisValidatorErrorConstriction error class."""
 
     pass
 
-class Pupil2IrisValidatorError_Offcenter(Exception):
-    """IsMaskGoodValidator error class."""
+class Pupil2IrisValidatorErrorOffcenter(Exception):
+    """Pupil2IrisValidatorErrorOffcenter error class."""
 
     pass
 

--- a/src/iris/nodes/validators/object_validators.py
+++ b/src/iris/nodes/validators/object_validators.py
@@ -54,17 +54,18 @@ class Pupil2IrisPropertyValidator(Callback, Algorithm):
         Raises:
             E.PupilIrisPropertyEstimationError: Raised if result isn't without previously specified boundaries.
         """
-        if not (
-            self.params.min_allowed_diameter_ratio
-            <= val_arguments.pupil_to_iris_diameter_ratio
-            <= self.params.max_allowed_diameter_ratio
-        ):
-            raise E.PupilIrisPropertyEstimationError(
-                f"p2i_property={val_arguments.pupil_to_iris_diameter_ratio} is not within [{self.params.min_allowed_diameter_ratio}, {self.params.max_allowed_diameter_ratio}]."
+
+        if val_arguments.pupil_to_iris_diameter_ratio < self.params.min_allowed_diameter_ratio:
+            raise E.Pupil2IrisValidatorError_Constriction(
+                f"p2i_property={val_arguments.pupil_to_iris_diameter_ratio} is below min threshold {self.params.min_allowed_diameter_ratio}. Pupil is too constricted."
+            )
+        if val_arguments.pupil_to_iris_diameter_ratio > self.params.max_allowed_diameter_ratio:
+            raise E.Pupil2IrisValidatorError_Dilation(
+                f"p2i_property={val_arguments.pupil_to_iris_diameter_ratio} is above max threshold {self.params.max_allowed_diameter_ratio}. Pupil is too dilated."
             )
         if val_arguments.pupil_to_iris_center_dist_ratio > self.params.max_allowed_center_dist_ratio:
-            raise E.PupilIrisPropertyEstimationError(
-                f"p2i_property={val_arguments.pupil_to_iris_center_dist_ratio} exceeds {self.params.max_allowed_center_dist_ratio}."
+            raise E.Pupil2IrisValidatorError_Offcenter(
+                f"p2i_property={val_arguments.pupil_to_iris_center_dist_ratio} exceeds {self.params.max_allowed_center_dist_ratio}. Pupil and iris are off-center."
             )
 
     def on_execute_end(self, result: PupilToIrisProperty) -> None:
@@ -408,3 +409,4 @@ class IsMaskTooSmallValidator(Callback, Algorithm):
             input_template (IrisTemplate): input IrisTemplate to be validated.
         """
         self.run(input_template)
+

--- a/src/iris/nodes/validators/object_validators.py
+++ b/src/iris/nodes/validators/object_validators.py
@@ -52,19 +52,21 @@ class Pupil2IrisPropertyValidator(Callback, Algorithm):
             p2i_property (PupilToIrisProperty): Computation result.
 
         Raises:
-            E.PupilIrisPropertyEstimationError: Raised if result isn't without previously specified boundaries.
+            E.Pupil2IrisValidatorErrorConstriction: Raised if pupil is constricted.
+            E.Pupil2IrisValidatorErrorDilation: Raised if pupil is dilated.
+            E.Pupil2IrisValidatorErrorOffcenter: Raised if pupil and iris are offcenter.
         """
 
         if val_arguments.pupil_to_iris_diameter_ratio < self.params.min_allowed_diameter_ratio:
-            raise E.Pupil2IrisValidatorError_Constriction(
+            raise E.Pupil2IrisValidatorErrorConstriction(
                 f"p2i_property={val_arguments.pupil_to_iris_diameter_ratio} is below min threshold {self.params.min_allowed_diameter_ratio}. Pupil is too constricted."
             )
         if val_arguments.pupil_to_iris_diameter_ratio > self.params.max_allowed_diameter_ratio:
-            raise E.Pupil2IrisValidatorError_Dilation(
+            raise E.Pupil2IrisValidatorErrorDilation(
                 f"p2i_property={val_arguments.pupil_to_iris_diameter_ratio} is above max threshold {self.params.max_allowed_diameter_ratio}. Pupil is too dilated."
             )
         if val_arguments.pupil_to_iris_center_dist_ratio > self.params.max_allowed_center_dist_ratio:
-            raise E.Pupil2IrisValidatorError_Offcenter(
+            raise E.Pupil2IrisValidatorErrorOffcenter(
                 f"p2i_property={val_arguments.pupil_to_iris_center_dist_ratio} exceeds {self.params.max_allowed_center_dist_ratio}. Pupil and iris are off-center."
             )
 

--- a/tests/unit_tests/nodes/validators/test_object_validators.py
+++ b/tests/unit_tests/nodes/validators/test_object_validators.py
@@ -59,10 +59,10 @@ def test_pupil_to_iris_property_validator(p2i_property: float) -> None:
 @pytest.mark.parametrize(
     "p2i_property, expected_error",
     [
-        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.9, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorError_Dilation),
-        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.19, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorError_Constriction),
-        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.51, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorError_Dilation),
-        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.2, pupil_to_iris_center_dist_ratio=0.8), E.Pupil2IrisValidatorError_Offcenter),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.9, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorErrorDilation),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.19, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorErrorConstriction),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.51, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorErrorDilation),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.2, pupil_to_iris_center_dist_ratio=0.8), E.Pupil2IrisValidatorErrorOffcenter),
     ],
     ids=["simple", "edge case: left boundary", "edge case: right boundary", "center distance too big"],
 )

--- a/tests/unit_tests/nodes/validators/test_object_validators.py
+++ b/tests/unit_tests/nodes/validators/test_object_validators.py
@@ -57,21 +57,21 @@ def test_pupil_to_iris_property_validator(p2i_property: float) -> None:
 
 
 @pytest.mark.parametrize(
-    "p2i_property",
+    "p2i_property, expected_error",
     [
-        PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.9, pupil_to_iris_center_dist_ratio=0.1),
-        PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.19, pupil_to_iris_center_dist_ratio=0.1),
-        PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.51, pupil_to_iris_center_dist_ratio=0.1),
-        PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.2, pupil_to_iris_center_dist_ratio=0.8),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.9, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorError_Dilation),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.19, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorError_Constriction),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.51, pupil_to_iris_center_dist_ratio=0.1), E.Pupil2IrisValidatorError_Dilation),
+        (PupilToIrisProperty(pupil_to_iris_diameter_ratio=0.2, pupil_to_iris_center_dist_ratio=0.8), E.Pupil2IrisValidatorError_Offcenter),
     ],
     ids=["simple", "edge case: left boundary", "edge case: right boundary", "center distance too big"],
 )
-def test_pupil_to_iris_property_validator_raise_exception1(p2i_property: float) -> None:
+def test_pupil_to_iris_property_validator_raise_exception1(p2i_property: float, expected_error: Exception) -> None:
     validator = obj_v.Pupil2IrisPropertyValidator(
         min_allowed_diameter_ratio=0.2, max_allowed_diameter_ratio=0.5, max_allowed_center_dist_ratio=0.5
     )
 
-    with pytest.raises(E.PupilIrisPropertyEstimationError):
+    with pytest.raises(expected_error):
         validator(p2i_property)
 
 


### PR DESCRIPTION
# {{finetune p2i validator errors}}

## PR description

report individual p2i validator errors (dilation, constriction and offcenter)

### Issue
we used to bundle them together, making it difficult to analyse.

### Solution
divide the error into more detailed error types

### Limitations
<!-- Document here any known limitation of your implementation. -->

## Type
<!-- Check a proper type with an 'x' ([x]). -->

- [x] Feature
- [x] Refactoring
- [ ] Bugfix
- [ ] DevOps
- [x] Testing

## Checklist
<!-- Please make sure you did all pre review requesting steps and check all with an 'x' ([x]). -->

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
