### PR TITLE
Refactor/output builders

### DIFF
--- a/src/iris/io/dataclasses.py
+++ b/src/iris/io/dataclasses.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Any, Dict, List, Literal, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Tuple, Union
 
 import numpy as np
-from pydantic import Field, NonNegativeInt, root_validator, validator
+from pydantic import BaseModel, Field, NonNegativeInt, root_validator, validator
 
+from iris.callbacks.pipeline_trace import PipelineCallTraceStorage
 from iris.io import validators as v
 from iris.io.class_configs import ImmutableModel
 from iris.utils.base64_encoding import base64_decode_array, base64_encode_array
@@ -722,3 +723,18 @@ class EyeOcclusion(ImmutableModel):
             EyeOcclusion: Deserialized object.
         """
         return EyeOcclusion(visible_fraction=data)
+
+
+class OutputFieldSpec(BaseModel):
+    """
+    Specification for a single output field in the pipeline result.
+
+    Attributes:
+        key (str): The name of the field in the output dictionary.
+        extractor (Callable[[PipelineCallTraceStorage], Any]): A function that takes a PipelineCallTraceStorage and returns the raw value.
+        safe_serialize (bool): If True, apply __safe_serialize to the extracted value before returning it.
+    """
+
+    key: str
+    extractor: Callable[[PipelineCallTraceStorage], Any]
+    safe_serialize: bool = False

--- a/src/iris/orchestration/output_builders.py
+++ b/src/iris/orchestration/output_builders.py
@@ -134,7 +134,7 @@ IRIS_PIPE_ORB_OUTPUT_SPEC = [
 IRIS_PIPE_DEBUG_OUTPUT_SPEC = [
     OutputFieldSpec(key="iris_template", extractor=lambda ct: ct.get("encoder"), safe_serialize=False),
     OutputFieldSpec(key="metadata", extractor=__get_iris_pipeline_metadata, safe_serialize=False),
-    OutputFieldSpec(key="segmentation_map", extractor=lambda ct: ct["segmentation"], safe_serialize=True),
+    OutputFieldSpec(key="segmentation_map", extractor=lambda ct: ct.get("segmentation"), safe_serialize=True),
     OutputFieldSpec(
         key="segmentation_binarization",
         extractor=lambda ct: {

--- a/src/iris/orchestration/output_builders.py
+++ b/src/iris/orchestration/output_builders.py
@@ -1,93 +1,46 @@
 import traceback
-from typing import Any, Dict, Optional
+from collections.abc import Mapping
+from typing import Any, Dict, List, Optional
 
 from iris._version import __version__
 from iris.callbacks.pipeline_trace import PipelineCallTraceStorage
-from iris.io.dataclasses import ImmutableModel
+from iris.io.dataclasses import ImmutableModel, OutputFieldSpec
 
 
-def build_simple_orb_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
-    """Build the output for the Orb.
+def _nested_safe_serialize(obj: Any) -> Any:
+    """
+    Apply __safe_serialize to obj, handling nested dicts by recursing into values.
+    Lists and tuples are handled by __safe_serialize itself.
+    """
+    if obj is None:
+        return None
+    # Handle mappings by serializing each value
+    if isinstance(obj, Mapping):
+        return {k: _nested_safe_serialize(v) for k, v in obj.items()}
+    # Fallback to the existing helper (handles ImmutableModel, list, tuple)
+    return __safe_serialize(obj)
+
+
+def _build_from_spec(call_trace: PipelineCallTraceStorage, spec: List[OutputFieldSpec]) -> Dict[str, Any]:
+    """
+    Generic builder that constructs an output dict based on a list of OutputFieldSpec.
 
     Args:
-        call_trace (PipelineCallTraceStorage): Pipeline call results storage.
+        call_trace (PipelineCallTraceStorage): The pipeline call trace storage object.
+        spec (List[OutputFieldSpec]): A list of OutputFieldSpec defining how to extract and optionally serialize each field.
 
     Returns:
-        Dict[str, Any]: {
-        "iris_template": (Optional[IrisTemplate]) the iris template object if the pipeline succeeded,
-        "error": (Optional[Dict]) the error dict if the pipeline returned an error,
-        "metadata": (Dict) the metadata dict,
-        }.
+        Dict[str, Any]: A dict mapping each spec.key to the (optionally serialized) extracted value.
     """
-    metadata = __get_metadata(call_trace=call_trace)
-    error = __get_error(call_trace=call_trace)
-    iris_template = call_trace["encoder"]
-
-    output = {
-        "error": error,
-        "iris_template": iris_template,
-        "metadata": metadata,
-    }
-
+    output: Dict[str, Any] = {}
+    for field in spec:
+        # Extract the raw value using the provided extractor function
+        val = field.extractor(call_trace)
+        # If requested, wrap complex objects in a safe-serialize step
+        if field.safe_serialize:
+            val = _nested_safe_serialize(val)
+        output[field.key] = val
     return output
-
-
-def build_orb_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
-    """Build the output for the Orb.
-
-    Args:
-        call_trace (PipelineCallTraceStorage): Pipeline call results storage.
-
-    Returns:
-        Dict[str, Any]: {
-        "iris_template": (Optional[Dict]) the iris template dict if the pipeline succeeded.
-        "error": (Optional[Dict]) the error dict if the pipeline returned an error.
-        "metadata": (Dict) the metadata dict.
-        }.
-    """
-    output = build_simple_orb_output(call_trace)
-    output["iris_template"] = __safe_serialize(output["iris_template"])
-
-    return output
-
-
-def build_simple_debugging_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
-    """Build the simplest output for debugging purposes.
-
-    Args:
-        call_trace (PipelineCallTraceStorage): Pipeline call results storage.
-
-    Returns:
-        Dict[str, Any]: Returns data to be stored in MongoDB.
-    """
-    iris_template = call_trace["encoder"]
-
-    metadata = __get_metadata(call_trace=call_trace)
-    error = __get_error(call_trace=call_trace)
-
-    segmap = call_trace["segmentation"]
-    geometry_mask, noise_mask = (
-        (None, None) if call_trace["segmentation_binarization"] is None else call_trace["segmentation_binarization"]
-    )
-    extrapolated_polygons = call_trace["geometry_estimation"]
-    normalized_iris = call_trace["normalization"]
-    iris_response = call_trace["filter_bank"]
-    iris_response_refined = call_trace["iris_response_refinement"]
-
-    return {
-        "iris_template": iris_template,
-        "metadata": metadata,
-        "segmentation_map": __safe_serialize(segmap),
-        "segmentation_binarization": {
-            "geometry": __safe_serialize(geometry_mask),
-            "noise": __safe_serialize(noise_mask),
-        },
-        "extrapolated_polygons": __safe_serialize(extrapolated_polygons),
-        "normalized_iris": __safe_serialize(normalized_iris),
-        "iris_response": __safe_serialize(iris_response),
-        "iris_response_refined": __safe_serialize(iris_response_refined),
-        "error": error,
-    }
 
 
 def __safe_serialize(object: Optional[ImmutableModel]) -> Optional[Dict[str, Any]]:
@@ -112,7 +65,7 @@ def __safe_serialize(object: Optional[ImmutableModel]) -> Optional[Dict[str, Any
         raise NotImplementedError(f"Object of type {type(object)} is not serializable.")
 
 
-def __get_metadata(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
+def __get_iris_pipeline_metadata(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
     """Produce metadata output from a call_trace.
 
     Args:
@@ -138,23 +91,6 @@ def __get_metadata(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
     }
 
 
-def build_debugging_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
-    """Build the output for debugging purposes.
-
-    Args:
-        call_trace (PipelineCallTraceStorage): Pipeline call results storage.
-
-    Returns:
-        Dict[str, Any]: Returns data to be stored in MongoDB.
-    """
-    output = build_simple_debugging_output(call_trace)
-
-    serialized_iris_template = __safe_serialize(output["iris_template"])
-    output["iris_template"] = serialized_iris_template
-
-    return output
-
-
 def __get_error(call_trace: PipelineCallTraceStorage) -> Optional[Dict[str, Any]]:
     """Produce error output from a call_trace.
 
@@ -175,3 +111,73 @@ def __get_error(call_trace: PipelineCallTraceStorage) -> Optional[Dict[str, Any]
         }
 
     return error
+
+
+# =============================================================================
+# Specs for different output variants
+# =============================================================================
+
+# Simple ORB output: raw iris_template, error info, and metadata
+IRIS_PIPE_SIMPLE_ORB_OUTPUT_SPEC = [
+    OutputFieldSpec(key="error", extractor=__get_error, safe_serialize=False),
+    OutputFieldSpec(key="iris_template", extractor=lambda ct: ct["encoder"], safe_serialize=False),
+    OutputFieldSpec(key="metadata", extractor=__get_iris_pipeline_metadata, safe_serialize=False),
+]
+
+IRIS_PIPE_ORB_OUTPUT_SPEC = [
+    OutputFieldSpec(key="error", extractor=__get_error, safe_serialize=False),
+    OutputFieldSpec(key="iris_template", extractor=lambda ct: ct["encoder"], safe_serialize=True),
+    OutputFieldSpec(key="metadata", extractor=__get_iris_pipeline_metadata, safe_serialize=False),
+]
+
+# Debugging output: includes various intermediate pipeline results
+IRIS_PIPE_DEBUG_OUTPUT_SPEC = [
+    OutputFieldSpec(key="iris_template", extractor=lambda ct: ct["encoder"], safe_serialize=False),
+    OutputFieldSpec(key="metadata", extractor=__get_iris_pipeline_metadata, safe_serialize=False),
+    OutputFieldSpec(key="segmentation_map", extractor=lambda ct: ct["segmentation"], safe_serialize=True),
+    OutputFieldSpec(
+        key="segmentation_binarization",
+        extractor=lambda ct: {
+            "geometry": None if ct["segmentation_binarization"] is None else ct["segmentation_binarization"][0],
+            "noise": None if ct["segmentation_binarization"] is None else ct["segmentation_binarization"][1],
+        },
+        safe_serialize=True,
+    ),
+    OutputFieldSpec(key="extrapolated_polygons", extractor=lambda ct: ct["geometry_estimation"], safe_serialize=True),
+    OutputFieldSpec(key="normalized_iris", extractor=lambda ct: ct["normalization"], safe_serialize=True),
+    OutputFieldSpec(key="iris_response", extractor=lambda ct: ct["filter_bank"], safe_serialize=True),
+    OutputFieldSpec(
+        key="iris_response_refined", extractor=lambda ct: ct["iris_response_refinement"], safe_serialize=True
+    ),
+    OutputFieldSpec(key="error", extractor=__get_error, safe_serialize=False),
+]
+
+# =============================================================================
+# Builder functions leveraging the generic engine
+# =============================================================================
+
+
+def build_simple_iris_pipeline_orb_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
+    """Construct simple ORB output: raw iris_template, error, and metadata."""
+    return _build_from_spec(call_trace, IRIS_PIPE_SIMPLE_ORB_OUTPUT_SPEC)
+
+
+def build_iris_pipeline_orb_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
+    """Construct ORB output with serialized iris_template."""
+    return _build_from_spec(call_trace, IRIS_PIPE_ORB_OUTPUT_SPEC)
+
+
+def build_simple_iris_pipeline_debugging_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
+    """Construct debugging output with intermediate results (raw values)."""
+    return _build_from_spec(call_trace, IRIS_PIPE_DEBUG_OUTPUT_SPEC)
+
+
+def build_iris_pipeline_debugging_output(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
+    """
+    Construct full debugging output: wrap simple_debugging and ensure
+    the iris_template is also safely serialized.
+    """
+    output = build_simple_iris_pipeline_debugging_output(call_trace)
+    # Safe-serialize the iris_template on top of the existing output
+    output["iris_template"] = __safe_serialize(output["iris_template"])
+    return output

--- a/src/iris/pipelines/iris_pipeline.py
+++ b/src/iris/pipelines/iris_pipeline.py
@@ -18,7 +18,11 @@ from iris.io.dataclasses import IRImage
 from iris.io.errors import IRISPipelineError
 from iris.orchestration.environment import Environment
 from iris.orchestration.error_managers import store_error_manager
-from iris.orchestration.output_builders import build_orb_output, build_simple_debugging_output, build_simple_orb_output
+from iris.orchestration.output_builders import (
+    build_iris_pipeline_orb_output,
+    build_simple_iris_pipeline_debugging_output,
+    build_simple_iris_pipeline_orb_output,
+)
 from iris.orchestration.pipeline_dataclasses import PipelineClass, PipelineMetadata, PipelineNode
 from iris.orchestration.validators import pipeline_config_duplicate_node_name_check
 from iris.utils.base64_encoding import base64_decode_str
@@ -28,7 +32,7 @@ class IRISPipeline(Algorithm):
     """Implementation of a fully configurable iris recognition pipeline."""
 
     DEBUGGING_ENVIRONMENT = Environment(
-        pipeline_output_builder=build_simple_debugging_output,
+        pipeline_output_builder=build_simple_iris_pipeline_debugging_output,
         error_manager=store_error_manager,
         disabled_qa=[
             iris.nodes.validators.object_validators.Pupil2IrisPropertyValidator,
@@ -44,7 +48,7 @@ class IRISPipeline(Algorithm):
     )
 
     ORB_ENVIRONMENT = Environment(
-        pipeline_output_builder=build_orb_output,
+        pipeline_output_builder=build_iris_pipeline_orb_output,
         error_manager=store_error_manager,
         call_trace_initialiser=PipelineCallTraceStorage.initialise,
     )
@@ -65,7 +69,7 @@ class IRISPipeline(Algorithm):
         self,
         config: Union[Dict[str, Any], Optional[str]] = None,
         env: Environment = Environment(
-            pipeline_output_builder=build_simple_orb_output,
+            pipeline_output_builder=build_simple_iris_pipeline_orb_output,
             error_manager=store_error_manager,
             call_trace_initialiser=PipelineCallTraceStorage.initialise,
         ),
@@ -278,7 +282,7 @@ class IRISPipeline(Algorithm):
         Returns:
             Dict[str, Any]: Configuration as a dictionary.
         """
-        if config is None or config == "":
+        if config is None or config == "":  # noqa
             with open(os.path.join(os.path.dirname(__file__), "confs", "pipeline.yaml"), "r") as f:
                 deserialized_config = yaml.safe_load(f)
         elif isinstance(config, str):

--- a/tests/e2e_tests/orchestration/test_e2e_output_builder.py
+++ b/tests/e2e_tests/orchestration/test_e2e_output_builder.py
@@ -7,7 +7,11 @@ import pytest
 
 from iris.callbacks.pipeline_trace import PipelineCallTraceStorage
 from iris.io.dataclasses import Landmarks
-from iris.orchestration.output_builders import build_orb_output, build_simple_debugging_output, build_simple_orb_output
+from iris.orchestration.output_builders import (
+    build_iris_pipeline_orb_output,
+    build_simple_iris_pipeline_debugging_output,
+    build_simple_iris_pipeline_orb_output,
+)
 from tests.e2e_tests.utils import (
     compare_debug_pipeline_outputs,
     compare_iris_pipeline_outputs,
@@ -48,7 +52,7 @@ def test_e2e_build_simple_output(
     mock_iris_pipeline_call_trace: PipelineCallTraceStorage,
     expected_simple_iris_pipeline_output: Tuple[Tuple[np.ndarray, np.ndarray], Landmarks, Dict[str, Any]],
 ) -> None:
-    build_orb_iris_pipeline_output = build_simple_orb_output(mock_iris_pipeline_call_trace)
+    build_orb_iris_pipeline_output = build_simple_iris_pipeline_orb_output(mock_iris_pipeline_call_trace)
 
     compare_simple_pipeline_outputs(expected_simple_iris_pipeline_output, build_orb_iris_pipeline_output)
 
@@ -57,7 +61,7 @@ def test_e2e_build_orb_output(
     mock_iris_pipeline_call_trace: PipelineCallTraceStorage,
     expected_orb_iris_pipeline_output: Tuple[Tuple[np.ndarray, np.ndarray], Landmarks, Dict[str, Any]],
 ) -> None:
-    build_orb_iris_pipeline_output = build_orb_output(mock_iris_pipeline_call_trace)
+    build_orb_iris_pipeline_output = build_iris_pipeline_orb_output(mock_iris_pipeline_call_trace)
 
     compare_iris_pipeline_outputs(expected_orb_iris_pipeline_output, build_orb_iris_pipeline_output)
 
@@ -66,6 +70,6 @@ def test_e2e_build_debug_output(
     mock_iris_pipeline_call_trace: PipelineCallTraceStorage,
     expected_debug_iris_pipeline_output: Tuple[Tuple[np.ndarray, np.ndarray], Landmarks, Dict[str, Any]],
 ) -> None:
-    build_debug_iris_pipeline_output = build_simple_debugging_output(mock_iris_pipeline_call_trace)
+    build_debug_iris_pipeline_output = build_simple_iris_pipeline_debugging_output(mock_iris_pipeline_call_trace)
 
     compare_debug_pipeline_outputs(expected_debug_iris_pipeline_output, build_debug_iris_pipeline_output)

--- a/tests/unit_tests/callbacks/test_pipeline_trace.py
+++ b/tests/unit_tests/callbacks/test_pipeline_trace.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 import pytest
 from _pytest.fixtures import FixtureRequest
 
-from iris.callbacks.pipeline_trace import NodeResultsWriter, PipelineCallTraceStorage, PipelineCallTraceStorageError
+from iris.callbacks.pipeline_trace import NodeResultsWriter, PipelineCallTraceStorage
 from iris.io.class_configs import Algorithm
 from iris.nodes.eye_properties_estimation.occlusion_calculator import OcclusionCalculator
 from iris.nodes.validators.object_validators import OcclusionValidator
@@ -151,6 +151,23 @@ def test_write_get_parameter(storage: PipelineCallTraceStorage, request: Fixture
     assert storage["alg2"] is None
     assert storage["alg3"] is None
     assert storage["alg4"] == mock_result
+
+
+@pytest.mark.parametrize(
+    "storage",
+    [("call_trace_storage")],
+    ids=["PipelineCallTraceStorage"],
+)
+def test_get_method_returns_none_for_missing_key(storage: PipelineCallTraceStorage, request: FixtureRequest) -> None:
+    """Test that PipelineCallTraceStorage.get() returns None for missing keys."""
+    storage = request.getfixturevalue(storage)
+    storage.write("alg1", "some_value")
+
+    # Test that existing key returns the value
+    assert storage.get("alg1") == "some_value"
+
+    # Test that missing key returns None
+    assert storage.get("nonexistent_key") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/orchestration/test_output_builders.py
+++ b/tests/unit_tests/orchestration/test_output_builders.py
@@ -1,0 +1,175 @@
+from unittest.mock import Mock
+
+import pytest
+
+from iris.callbacks.pipeline_trace import PipelineCallTraceStorage
+from iris.io.dataclasses import OutputFieldSpec
+from iris.orchestration.output_builders import (
+    _build_from_spec,
+    build_iris_pipeline_orb_output,
+    build_simple_iris_pipeline_debugging_output,
+    build_simple_iris_pipeline_orb_output,
+)
+
+
+class TestOutputBuildersWithMissingKeys:
+    """Test output builders behavior when keys are missing from call_trace."""
+
+    @pytest.fixture
+    def mock_call_trace_with_missing_keys(self):
+        """Create a mock call_trace that has some keys missing."""
+        # Create a call_trace with minimal required keys
+        call_trace = PipelineCallTraceStorage(results_names=["encoder"])
+
+        # Mock the input to avoid errors in metadata extraction
+        mock_input = Mock()
+        mock_input.width = 640
+        mock_input.height = 480
+        mock_input.eye_side = "left"
+        call_trace.write_input(mock_input)
+
+        # Deliberately don't write values for most keys, so they remain None
+        # Don't write anything to encoder either, so it remains None
+        # This will test the case where the key exists in storage but has None value
+
+        return call_trace
+
+    @pytest.fixture
+    def mock_call_trace_with_simple_value(self):
+        """Create a mock call_trace with a simple value for testing simple output builders."""
+        # Create a call_trace with minimal required keys
+        call_trace = PipelineCallTraceStorage(results_names=["encoder"])
+
+        # Mock the input to avoid errors in metadata extraction
+        mock_input = Mock()
+        mock_input.width = 640
+        mock_input.height = 480
+        mock_input.eye_side = "left"
+        call_trace.write_input(mock_input)
+
+        # Write a simple value for encoder (for simple output builders that don't serialize)
+        call_trace.write("encoder", "mock_iris_template")
+
+        return call_trace
+
+    def test_build_iris_pipeline_orb_output_with_missing_keys(self, mock_call_trace_with_missing_keys):
+        """Test that build_iris_pipeline_orb_output includes None values for missing keys."""
+        result = build_iris_pipeline_orb_output(mock_call_trace_with_missing_keys)
+
+        # Check that the output contains the expected keys
+        assert "error" in result
+        assert "iris_template" in result
+        assert "metadata" in result
+
+        # Check that error is None (since no error was set)
+        assert result["error"] is None
+
+        # Check that iris_template is None (since we didn't write anything to encoder)
+        assert result["iris_template"] is None
+
+        # Check that metadata contains None values for missing keys
+        metadata = result["metadata"]
+        assert metadata["eye_centers"] is None
+        assert metadata["pupil_to_iris_property"] is None
+        assert metadata["offgaze_score"] is None
+        assert metadata["eye_orientation"] is None
+        assert metadata["occlusion90"] is None
+        assert metadata["occlusion30"] is None
+        assert metadata["iris_bbox"] is None
+        assert metadata["sharpness_score"] is None
+
+    def test_build_simple_iris_pipeline_orb_output_with_missing_keys(self, mock_call_trace_with_simple_value):
+        """Test that build_simple_iris_pipeline_orb_output includes None values for missing keys."""
+        result = build_simple_iris_pipeline_orb_output(mock_call_trace_with_simple_value)
+
+        # Check that the output contains the expected keys
+        assert "error" in result
+        assert "iris_template" in result
+        assert "metadata" in result
+
+        # Check that error is None (since no error was set)
+        assert result["error"] is None
+
+        # Check that iris_template has the value we set
+        assert result["iris_template"] == "mock_iris_template"
+
+    def test_build_simple_iris_pipeline_debugging_output_with_missing_keys(self, mock_call_trace_with_missing_keys):
+        """Test that build_simple_iris_pipeline_debugging_output includes None values for missing keys."""
+        result = build_simple_iris_pipeline_debugging_output(mock_call_trace_with_missing_keys)
+
+        # Check that keys with missing values are None
+        assert result["extrapolated_polygons"] is None
+        assert result["normalized_iris"] is None
+        assert result["iris_response"] is None
+        assert result["iris_response_refined"] is None
+        assert result["error"] is None
+
+    def test_custom_spec_with_missing_key(self, mock_call_trace_with_simple_value):
+        """Test that _build_from_spec includes None for missing keys in custom specs."""
+        # Create a custom spec that tries to extract a key that doesn't exist
+        custom_spec = [
+            OutputFieldSpec(key="existing_key", extractor=lambda ct: ct.get("encoder"), safe_serialize=False),
+            OutputFieldSpec(key="missing_key", extractor=lambda ct: ct.get("nonexistent_key"), safe_serialize=False),
+            OutputFieldSpec(
+                key="another_missing_key", extractor=lambda ct: ct.get("another_nonexistent_key"), safe_serialize=True
+            ),
+        ]
+
+        result = _build_from_spec(mock_call_trace_with_simple_value, custom_spec)
+
+        # Check that existing key has the expected value
+        assert result["existing_key"] == "mock_iris_template"
+
+        # Check that missing keys have None values
+        assert result["missing_key"] is None
+        assert result["another_missing_key"] is None
+
+        # Verify all expected keys are present
+        assert set(result.keys()) == {"existing_key", "missing_key", "another_missing_key"}
+
+    def test_missing_keys_result_in_key_none_pairs_in_output(self):
+        """
+        Explicit test showing that if a key is not in the call_trace,
+        the output will contain key: None in it.
+        """
+        # Create a call_trace with no keys written (all will be None)
+        call_trace = PipelineCallTraceStorage(results_names=[])
+
+        # Mock the input to avoid errors in metadata extraction
+        mock_input = Mock()
+        mock_input.width = 640
+        mock_input.height = 480
+        mock_input.eye_side = "left"
+        call_trace.write_input(mock_input)
+
+        # Create a custom spec that tries to extract keys that don't exist
+        custom_spec = [
+            OutputFieldSpec(
+                key="missing_key_1", extractor=lambda ct: ct.get("nonexistent_key_1"), safe_serialize=False
+            ),
+            OutputFieldSpec(
+                key="missing_key_2", extractor=lambda ct: ct.get("nonexistent_key_2"), safe_serialize=False
+            ),
+            OutputFieldSpec(key="missing_key_3", extractor=lambda ct: ct.get("nonexistent_key_3"), safe_serialize=True),
+        ]
+
+        result = _build_from_spec(call_trace, custom_spec)
+
+        # Verify that the output contains the keys with None values
+        expected_output = {
+            "missing_key_1": None,
+            "missing_key_2": None,
+            "missing_key_3": None,
+        }
+
+        assert result == expected_output
+
+        # Explicitly verify each key: None pair
+        assert result["missing_key_1"] is None
+        assert result["missing_key_2"] is None
+        assert result["missing_key_3"] is None
+
+        # Verify all keys are present in the output
+        assert "missing_key_1" in result
+        assert "missing_key_2" in result
+        assert "missing_key_3" in result

--- a/tests/unit_tests/pipelines/test_iris_pipeline.py
+++ b/tests/unit_tests/pipelines/test_iris_pipeline.py
@@ -15,7 +15,10 @@ from iris.io.class_configs import Algorithm
 from iris.io.errors import IRISPipelineError
 from iris.orchestration.environment import Environment
 from iris.orchestration.error_managers import raise_error_manager, store_error_manager
-from iris.orchestration.output_builders import build_orb_output, build_simple_debugging_output
+from iris.orchestration.output_builders import (
+    build_iris_pipeline_orb_output,
+    build_simple_iris_pipeline_debugging_output,
+)
 from iris.orchestration.pipeline_dataclasses import PipelineClass
 from iris.pipelines.iris_pipeline import IRISPipeline
 from iris.utils.base64_encoding import base64_encode_str
@@ -192,7 +195,7 @@ def test_check_pipeline_coherency_fails(config: Optional[str], expectation):
         (
             "fake_ir_image",
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -201,7 +204,7 @@ def test_check_pipeline_coherency_fails(config: Optional[str], expectation):
         (
             "ir_image",
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -210,7 +213,7 @@ def test_check_pipeline_coherency_fails(config: Optional[str], expectation):
         (
             "fake_ir_image",
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=store_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -219,7 +222,7 @@ def test_check_pipeline_coherency_fails(config: Optional[str], expectation):
         (
             "ir_image",
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=store_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -247,7 +250,7 @@ def test_error_manager(input: str, env: Environment, expectation, request: Fixtu
         (
             "ir_image",
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -258,7 +261,7 @@ def test_error_manager(input: str, env: Environment, expectation, request: Fixtu
         (
             "fake_ir_image",
             Environment(
-                pipeline_output_builder=build_simple_debugging_output,
+                pipeline_output_builder=build_simple_iris_pipeline_debugging_output,
                 error_manager=store_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -268,7 +271,7 @@ def test_error_manager(input: str, env: Environment, expectation, request: Fixtu
         (
             "ir_image",
             Environment(
-                pipeline_output_builder=build_simple_debugging_output,
+                pipeline_output_builder=build_simple_iris_pipeline_debugging_output,
                 error_manager=store_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -362,7 +365,7 @@ def test_call_trace_clearance(ir_image: np.ndarray) -> None:
             None,
             [],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 disabled_qa=[],
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
@@ -374,7 +377,7 @@ def test_call_trace_clearance(ir_image: np.ndarray) -> None:
             None,
             [],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 disabled_qa=[iris.nodes.validators.object_validators.IsPupilInsideIrisValidator],
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
@@ -395,7 +398,7 @@ def test_call_trace_clearance(ir_image: np.ndarray) -> None:
             ],
             [{"min_iris_length": 300, "min_pupil_length": 300}, {"min_iris_length": 400, "min_pupil_length": 400}],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 disabled_qa=[iris.nodes.validators.object_validators.IsPupilInsideIrisValidator],
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
@@ -407,7 +410,7 @@ def test_call_trace_clearance(ir_image: np.ndarray) -> None:
             None,
             [],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 disabled_qa=[iris.nodes.validators.object_validators.PolygonsLengthValidator],
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
@@ -428,7 +431,7 @@ def test_call_trace_clearance(ir_image: np.ndarray) -> None:
             ],
             [{"min_iris_length": 300, "min_pupil_length": 300}],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 disabled_qa=[
                     iris.nodes.validators.object_validators.OcclusionValidator,
@@ -452,7 +455,7 @@ def test_call_trace_clearance(ir_image: np.ndarray) -> None:
             ],
             [],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 disabled_qa=[
                     iris.nodes.validators.object_validators.OcclusionValidator,
@@ -512,7 +515,7 @@ def test_instanciate_node(
             [],
             [],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -555,7 +558,7 @@ def test_instanciate_node(
                 ),
             ],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 call_trace_initialiser=PipelineCallTraceStorage.initialise,
             ),
@@ -591,7 +594,7 @@ def test_instanciate_node(
                 iris.nodes.geometry_estimation.linear_extrapolation.LinearExtrapolation(dphi=142.857, callbacks=[]),
             ],
             Environment(
-                pipeline_output_builder=build_orb_output,
+                pipeline_output_builder=build_iris_pipeline_orb_output,
                 error_manager=raise_error_manager,
                 disabled_qa=[
                     iris.nodes.validators.object_validators.OffgazeValidator,


### PR DESCRIPTION
# Refactor output_builders

## PR description

Refactor the code of the `output_builders` module in order to make it more readable and easier extendable 

### Issue

### Solution

### Limitations
All builders are still separate functions, which means that if there is another pipeline or something, more of those will be needed, making the code less readable

## Type

- [ ] Feature
- [x] Refactoring
- [ ] Bugfix
- [ ] DevOps
- [ ] Testing

## Checklist

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
