### PR TITLE
BUGFIX: add estimate method

### DIFF
--- a/src/iris/pipelines/base_pipeline.py
+++ b/src/iris/pipelines/base_pipeline.py
@@ -67,6 +67,18 @@ class BasePipeline(Algorithm, Generic[InputType, OutputType], abc.ABC):
         self.nodes = self._instanciate_nodes()
         self.call_trace = self.env.call_trace_initialiser(nodes=self.nodes, pipeline_nodes=self.params.pipeline)
 
+    def estimate(self, pipeline_input: InputType, *args: Any, **kwargs: Any) -> OutputType:
+        """Wrap the `run` method to match the Orb system AI models call interface.
+
+        Args:
+            pipeline_input (InputType): Input to the pipeline (type defined by subclass).
+            *args (Any): Optional positional arguments for extensibility.
+            **kwargs (Any): Optional keyword arguments for extensibility.
+        Returns:
+            OutputType: Output from the pipeline (type defined by subclass).
+        """
+        return self.run(pipeline_input, *args, **kwargs)
+
     def run(self, pipeline_input: InputType, *args: Any, **kwargs: Any) -> OutputType:
         """
         Main pipeline execution loop. Handles input, node execution, and output.

--- a/src/iris/pipelines/iris_pipeline.py
+++ b/src/iris/pipelines/iris_pipeline.py
@@ -99,7 +99,7 @@ class IRISPipeline(BasePipeline):
         Returns:
             Any: Output created by builder specified in environment.pipeline_output_builder.
         """
-        return super().estimate(img_data, eye_side, *args, **kwargs)
+        return self.run(img_data, eye_side, *args, **kwargs)
 
     def run(self, img_data: np.ndarray, eye_side: Literal["left", "right"], *args, **kwargs) -> Any:
         """

--- a/src/iris/pipelines/iris_pipeline.py
+++ b/src/iris/pipelines/iris_pipeline.py
@@ -87,7 +87,33 @@ class IRISPipeline(BasePipeline):
         deserialized_config = self.load_config(config) if isinstance(config, str) or config is None else config
         super().__init__(deserialized_config, env)
 
+    def estimate(self, img_data: np.ndarray, eye_side: Literal["left", "right"], *args, **kwargs) -> Any:
+        """Wrap the `run` method to match the Orb system AI models call interface.
+
+        Args:
+            img_data (np.ndarray): Input image data.
+            eye_side (Literal["left", "right"]): Eye side.
+            *args: Optional positional arguments for extensibility.
+            **kwargs: Optional keyword arguments for extensibility.
+
+        Returns:
+            Any: Output created by builder specified in environment.pipeline_output_builder.
+        """
+        return super().estimate(img_data, eye_side, *args, **kwargs)
+
     def run(self, img_data: np.ndarray, eye_side: Literal["left", "right"], *args, **kwargs) -> Any:
+        """
+        Wrap the `run` method to match the Orb system AI models call interface.
+
+        Args:
+            img_data (np.ndarray): Input Infrared image data.
+            eye_side (Literal["left", "right"]): Eye side.
+            *args: Optional positional arguments for extensibility.
+            **kwargs: Optional keyword arguments for extensibility.
+
+        Returns:
+            Any: Output created by builder specified in environment.pipeline_output_builder.
+        """
         pipeline_input = {"img_data": img_data, "eye_side": eye_side}
         return super().run(pipeline_input, *args, **kwargs)
 

--- a/tests/unit_tests/pipelines/test_base_pipeline.py
+++ b/tests/unit_tests/pipelines/test_base_pipeline.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for BasePipeline class.
+
+This module contains tests that verify the behavior of the BasePipeline class,
+specifically focusing on the equivalence between the `estimate()` and `run()` methods.
+
+The main test validates that:
+1. The `estimate()` method produces identical output to the `run()` method
+2. Both methods handle additional arguments and keyword arguments consistently
+3. The `estimate()` method internally calls the `run()` method (as documented)
+4. Multiple calls to both methods remain consistent
+
+These tests ensure that the `estimate()` method correctly wraps the `run()` method
+to match the Orb system AI models call interface, as stated in the docstring.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import Mock
+
+import pytest
+
+from iris.callbacks.pipeline_trace import PipelineCallTraceStorage
+from iris.orchestration.environment import Environment
+from iris.orchestration.error_managers import store_error_manager
+from iris.orchestration.pipeline_dataclasses import PipelineMetadata, PipelineNode
+from iris.pipelines.base_pipeline import BasePipeline
+
+
+def custom_test_output_builder(call_trace: PipelineCallTraceStorage) -> Dict[str, Any]:
+    """Custom output builder for testing that handles dictionary inputs."""
+    return {"input": call_trace.get_input(), "metadata": {"test": "output"}, "error": call_trace.get("error")}
+
+
+class ConcretePipeline(BasePipeline[Dict[str, Any], Dict[str, Any]]):
+    """Concrete implementation of BasePipeline for testing purposes."""
+
+    class Parameters(BasePipeline.Parameters):
+        """Parameters class for ConcretePipeline."""
+
+        metadata: PipelineMetadata
+        pipeline: List[PipelineNode]
+
+    __parameters_type__ = Parameters
+
+    def _handle_input(self, pipeline_input: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
+        """Handle input by writing to call trace."""
+        self.call_trace.write_input(pipeline_input)
+
+    def _handle_output(self, *args, **kwargs) -> Dict[str, Any]:
+        """Handle output by building from call trace."""
+        return self.env.pipeline_output_builder(self.call_trace)
+
+
+@pytest.fixture
+def mock_environment():
+    """Create a mock environment for testing."""
+    return Environment(
+        pipeline_output_builder=custom_test_output_builder,
+        error_manager=store_error_manager,
+        call_trace_initialiser=PipelineCallTraceStorage.initialise,
+    )
+
+
+@pytest.fixture
+def simple_config():
+    """Create a simple pipeline configuration for testing."""
+    return {"metadata": {"pipeline_name": "test_pipeline", "iris_version": "1.6.1"}, "pipeline": []}
+
+
+@pytest.fixture
+def test_input():
+    """Create test input data."""
+    return {"test_data": "sample_value", "number": 42}
+
+
+class TestBasePipeline:
+    """Test suite for BasePipeline class."""
+
+    def test_estimate_and_run_produce_same_output(self, simple_config, mock_environment, test_input):
+        """Test that estimate() and run() methods produce identical outputs."""
+        # Create pipeline instance
+        pipeline = ConcretePipeline(config=simple_config, env=mock_environment)
+
+        # Run both methods with the same input
+        estimate_result = pipeline.estimate(test_input)
+        run_result = pipeline.run(test_input)
+
+        # Assert that both methods produce the same output
+        assert estimate_result == run_result
+
+    def test_estimate_and_run_with_args_kwargs(self, simple_config, mock_environment, test_input):
+        """Test that estimate() and run() produce same output with additional args and kwargs."""
+        # Create pipeline instance
+        pipeline = ConcretePipeline(config=simple_config, env=mock_environment)
+
+        # Test with additional positional and keyword arguments
+        extra_arg = "extra_positional"
+        extra_kwarg = {"extra": "keyword"}
+
+        # Run both methods with the same input and additional arguments
+        estimate_result = pipeline.estimate(test_input, extra_arg, extra_param=extra_kwarg)
+        run_result = pipeline.run(test_input, extra_arg, extra_param=extra_kwarg)
+
+        # Assert that both methods produce the same output
+        assert estimate_result == run_result
+
+    def test_estimate_calls_run_internally(self, simple_config, mock_environment, test_input):
+        """Test that estimate() method internally calls run() method."""
+        # Create pipeline instance
+        pipeline = ConcretePipeline(config=simple_config, env=mock_environment)
+
+        # Mock the run method to verify it's called by estimate
+        original_run = pipeline.run
+        pipeline.run = Mock(return_value={"mocked": "result"})
+
+        # Call estimate
+        result = pipeline.estimate(test_input, "arg1", kwarg1="value1")
+
+        # Verify run was called with the same arguments
+        pipeline.run.assert_called_once_with(test_input, "arg1", kwarg1="value1")
+        assert result == {"mocked": "result"}
+
+        # Restore original run method
+        pipeline.run = original_run
+
+    def test_estimate_and_run_multiple_calls_consistency(self, simple_config, mock_environment, test_input):
+        """Test that multiple calls to estimate() and run() remain consistent."""
+        # Create pipeline instance
+        pipeline = ConcretePipeline(config=simple_config, env=mock_environment)
+
+        # Make multiple calls and verify consistency
+        for i in range(3):
+            estimate_result = pipeline.estimate(test_input)
+            run_result = pipeline.run(test_input)
+
+            assert estimate_result == run_result, f"Mismatch on iteration {i}"

--- a/tests/unit_tests/pipelines/test_iris_pipeline.py
+++ b/tests/unit_tests/pipelines/test_iris_pipeline.py
@@ -762,7 +762,6 @@ def test_estimate_run_equivalence_with_call_method(ir_image: np.ndarray):
     call_result = iris_pipeline(ir_image, eye_side="left")
 
     # All three should produce identical results
-    # Default IRISPipeline uses build_simple_iris_pipeline_orb_output, so we need compare_simple_pipeline_outputs
     compare_simple_pipeline_outputs(estimate_result, run_result)
     compare_simple_pipeline_outputs(run_result, call_result)
     compare_simple_pipeline_outputs(estimate_result, call_result)


### PR DESCRIPTION
# BUGFIX: add estimate method to pipeline classes

## PR description

Adds an `estimate()` method to `BasePipeline` and `IRISPipeline` classes to match the Orb system AI models call interface.

### Issue
The estimate method has been forgotten and an absence of the corresponding unit-tests didn't catch the problem/

### Changes
- **`BasePipeline`**: Added `estimate()` method that wraps the existing `run()` method
- **`IRISPipeline`**: Added `estimate()` method override with proper type hints for iris-specific inputs
- **Tests**: Added comprehensive unit tests verifying `estimate()` and `run()` method equivalence

### Technical Details
- The `estimate()` method provides the same functionality as `run()` but matches the expected interface for Orb system integration

### Testing
- ✅ Unit tests verify output equivalence between `estimate()` and `run()`
- ✅ Tests confirm proper handling of additional args/kwargs
- ✅ Tests validate that `estimate()` internally calls `run()`
- ✅ Multiple call consistency tests included

### Limitations
 -

## Type

- [ ] Feature
- [ ] Refactoring
- [x] Bugfix
- [ ] DevOps
- [x] Testing

## Checklist

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
