### PR TITLE
Yichen1 aic 5912 refactoring weighted hd in open iris

### DIFF
--- a/src/iris/nodes/matcher/hamming_distance_matcher.py
+++ b/src/iris/nodes/matcher/hamming_distance_matcher.py
@@ -18,7 +18,7 @@ class HammingDistanceMatcher(Matcher):
        4) If parameters norm_mean and weights are both defined, calculate weighted normalized Hamming distance (WNHD) based on IB_Counts, MB_Counts, norm_mean and weights.
        5) Otherwise, calculate Hamming distance (HD) based on IB_Counts and MB_Counts.
        6) If parameter rotation_shift is > 0, repeat the above steps for additional rotations of the iriscode.
-       7) Return the minimium distance from above calculations.
+       7) Return the minimum distance from above calculations.
     """
 
     class Parameters(Matcher.Parameters):
@@ -29,6 +29,7 @@ class HammingDistanceMatcher(Matcher):
         norm_mean: confloat(ge=0, le=1, strict=True)
         norm_gradient: float
         separate_half_matching: bool
+        weights_path: Optional[str]
         weights: Optional[List[np.ndarray]]
 
     __parameters_type__ = Parameters
@@ -40,6 +41,7 @@ class HammingDistanceMatcher(Matcher):
         norm_mean: confloat(ge=0, le=1, strict=True) = 0.45,
         norm_gradient: float = 0.00005,
         separate_half_matching: bool = True,
+        weights_path: Optional[str] = None,
         weights: Optional[List[np.ndarray]] = None,
     ) -> None:
         """Assign parameters.
@@ -47,17 +49,21 @@ class HammingDistanceMatcher(Matcher):
         Args:
             rotation_shift (Optional[conint(ge=0, strict=True)], optional): Rotation shifts allowed in matching (in columns). Defaults to 15.
             normalise (bool, optional): Flag to normalize HD. Defaults to True.
-            norm_mean (Optional[confloat(ge=0, le = 1, strict=True)], optional): Nonmatch distance used for normalized HD. Optional paremeter for normalized HD. Defaults to 0.45.
+            norm_mean (Optional[confloat(ge=0, le = 1, strict=True)], optional): Nonmatch distance used for normalized HD. Optional parameter for normalized HD. Defaults to 0.45.
             norm_gradient: float, optional): Gradient for linear approximation of normalization term. Defaults to 0.00005.
             separate_half_matching (bool, optional): Separate the upper and lower halves for matching. Defaults to True.
-            weights (Optional[List[np.ndarray]], optional): list of weights table. Optional paremeter for weighted HD. Defaults to None.
+            weights_path (Optional[str], optional): Path to the weights table. Optional parameter for weighted HD. Defaults to None.
+            weights (Optional[List[np.ndarray]], optional): list of weights table. Optional parameter for weighted HD. Defaults to None.
         """
+        if weights_path is not None:
+            weights = self.load_weights(weights_path)
         super().__init__(
             rotation_shift=rotation_shift,
             normalise=normalise,
             norm_mean=norm_mean,
             norm_gradient=norm_gradient,
             separate_half_matching=separate_half_matching,
+            weights_path=weights_path,
             weights=weights,
         )
 

--- a/src/iris/nodes/matcher/hamming_distance_matcher_interface.py
+++ b/src/iris/nodes/matcher/hamming_distance_matcher_interface.py
@@ -1,5 +1,6 @@
 import abc
 from typing import Any, List
+import numpy as np
 
 from pydantic import conint
 
@@ -24,6 +25,28 @@ class Matcher(abc.ABC):
             rotation_shift (int = 15): rotation allowed in matching, converted to columns. Defaults to 15.
         """
         self.params = self.__parameters_type__(**kwargs)
+    
+    def load_weights(self, weights_path: str) -> List[np.array]:
+        """Load weights from a file.
+
+        Args:
+            weights_path (str): Path to the weights file.
+
+        Returns:
+            List[Any]: Loaded weights.
+        """
+        with open(weights_path, 'rb') as f:
+            try:
+                weights = np.load(f, allow_pickle=True)
+                if isinstance(weights, np.ndarray):
+                    return [weights]
+                elif isinstance(weights, list):
+                    return weights
+                else:
+                    raise ValueError("Weights file does not contain a valid format.")
+            except Exception as e:
+                print(f"Error loading weights: {e}")
+        return []
 
     @abc.abstractmethod
     def run(self, template_probe: IrisTemplate, template_gallery: IrisTemplate) -> float:

--- a/src/iris/nodes/matcher/utils.py
+++ b/src/iris/nodes/matcher/utils.py
@@ -25,7 +25,7 @@ def normalized_HD(irisbitcount: int, maskbitcount: int, norm_mean: float, norm_g
 
 
 def get_bitcounts(template_probe: IrisTemplate, template_gallery: IrisTemplate, shift: int) -> np.ndarray:
-    """Get bitcounts in iris and mask codes.
+    """Get bit counts in iris and mask codes.
 
     Args:
         template_probe (IrisTemplate): Iris template from probe.
@@ -33,7 +33,7 @@ def get_bitcounts(template_probe: IrisTemplate, template_gallery: IrisTemplate, 
         shift (int): Rotation shift (in columns)
 
     Returns:
-        np.ndarray: Bitcounts in iris and mask codes.
+        np.ndarray: Bit counts in iris and mask codes.
     """
     irisbits = [
         np.roll(probe_code, shift, axis=1) != gallery_code
@@ -52,13 +52,13 @@ def count_nonmatchbits(
     half_width: Optional[List[int]] = None,
     weights: Optional[List[np.ndarray]] = None,
 ) -> Union[Tuple[int, int], Tuple[List[int], List[int]]]:
-    """Count nonmatch bits for Hammming distance.
+    """Count nonmatch bits for Hamming distance.
 
     Args:
         irisbits (np.ndarray): Nonmatch irisbits.
         maskbits (np.ndarray): Common maskbits.
-        half_width (Optional[np.ndarray] = None): List of half of code width. Optional paremeter for scoring the upper and lower halves separately. Defaults to None.
-        weights (Optional[np.ndarray] = None): List of weights table. Optional paremeter for weighted HD. Defaults to None.
+        half_width (Optional[np.ndarray] = None): List of half of code width. Optional parameter for scoring the upper and lower halves separately. Defaults to None.
+        weights (Optional[np.ndarray] = None): List of weights table. Optional parameter for weighted HD. Defaults to None.
 
     Returns:
         Tuple[int, int]: Total nonmatch iriscode bit count and common maskcode bit count, could be a list for top and bottom iris separately.
@@ -72,10 +72,10 @@ def count_nonmatchbits(
 
     if half_width:
         totalirisbitcount = np.sum(
-            [[np.sum(x[hw:, ...]), np.sum(x[:hw, ...])] for x, hw in zip(irisbitcount, half_width)], axis=0
+            [[np.sum(x[hw:, ...])*2, np.sum(x[:hw, ...])*2] for x, hw in zip(irisbitcount, half_width)], axis=0
         )
         totalmaskbitcount = np.sum(
-            [[np.sum(y[hw:, ...]), np.sum(y[:hw, ...])] for y, hw in zip(maskbitcount, half_width)], axis=0
+            [[np.sum(y[hw:, ...])*2, np.sum(y[:hw, ...])*2] for y, hw in zip(maskbitcount, half_width)], axis=0
         )
     else:
         totalirisbitcount = np.sum(irisbitcount)
@@ -103,7 +103,7 @@ def simple_hamming_distance(
         norm_gradient (float): Gradient for linear approximation of normalization term. Defaults to 0.00005.
 
     Returns:
-        Tuple[float, int]: Miminum Hamming distance and corresonding rotation shift.
+        Tuple[float, int]: Minimum Hamming distance and corresponding rotation shift.
     """
     for probe_code, gallery_code in zip(template_probe.iris_codes, template_gallery.iris_codes):
         if probe_code.shape != gallery_code.shape:
@@ -134,7 +134,7 @@ def simple_hamming_distance(
 def hamming_distance(
     template_probe: IrisTemplate,
     template_gallery: IrisTemplate,
-    rotation_shift: int,
+    rotation_shift: int = 15,
     normalise: bool = False,
     norm_mean: float = 0.45,
     norm_gradient: float = 0.00005,
@@ -146,18 +146,18 @@ def hamming_distance(
     Args:
         template_probe (IrisTemplate): Iris template from probe.
         template_gallery (IrisTemplate): Iris template from gallery.
-        rotation_shift (int): Rotation allowed in matching, converted to columns.
+        rotation_shift (int): Rotation allowed in matching, converted to columns. Defaults to 15.
         normalise (bool, optional): Flag to normalize HD. Defaults to False.
         norm_mean (float, optional): Nonmatch mean distance for normalized HD. Defaults to 0.45.
         norm_gradient (float): Gradient for linear approximation of normalization term. Defaults to 0.00005.
         separate_half_matching (bool, optional): Separate the upper and lower halves for matching. Defaults to False.
-        weights (Optional[List[np.ndarray]], optional): List of weights table. Optional paremeter for weighted HD. Defaults to None.
+        weights (Optional[List[np.ndarray]], optional): List of weights table. Optional parameter for weighted HD. Defaults to None.
 
     Raises:
         MatcherError: If probe and gallery iris codes are of different sizes or number of columns of iris codes is not even or If weights (when defined) and iris codes are of different sizes.
 
     Returns:
-        Tuple[float, int]: Miminum Hamming distance and corresonding rotation shift.
+        Tuple[float, int]: Minimum Hamming distance and corresponding rotation shift.
     """
     half_codewidth = []
 

--- a/tests/e2e_tests/nodes/matcher/test_e2e_hamming_distance_matcher.py
+++ b/tests/e2e_tests/nodes/matcher/test_e2e_hamming_distance_matcher.py
@@ -22,11 +22,11 @@ def load_mock_pickle(name: str) -> Any:
     [
         pytest.param(10, False, 0.45, 0.00005, True, None, 0.0),
         pytest.param(15, False, 0.45, 0.00005, False, None, 0.0),
-        pytest.param(10, True, 0.45, 0.00005, True, None, 0.0347),
+        pytest.param(10, True, 0.45, 0.00005, True, None, 0.0026),
         pytest.param(15, True, 0.45, 0.00005, False, None, 0),
         pytest.param(10, False, 0.45, 0.00005, True, [np.ones([16, 256, 2]), np.ones([16, 256, 2])], 0.0),
         pytest.param(15, False, 0.45, 0.00005, False, [np.ones([16, 256, 2]), np.ones([16, 256, 2])], 0.0),
-        pytest.param(10, True, 0.45, 0.00005, True, [np.ones([16, 256, 2]), np.ones([16, 256, 2])], 0.0347),
+        pytest.param(10, True, 0.45, 0.00005, True, [np.ones([16, 256, 2]), np.ones([16, 256, 2])], 0.0026),
         pytest.param(15, True, 0.45, 0.00005, False, [np.ones([16, 256, 2]), np.ones([16, 256, 2])], 0.0),
         pytest.param(10, True, 0.45, 0.001, True, [np.ones([16, 256, 2]), np.ones([16, 256, 2])], 0.0),
         pytest.param(15, True, 0.45, 0.00008, False, [np.ones([16, 256, 2]), np.ones([16, 256, 2])], 0.0),

--- a/tests/unit_tests/nodes/matcher/test_matcher_utils.py
+++ b/tests/unit_tests/nodes/matcher/test_matcher_utils.py
@@ -136,7 +136,7 @@ from iris.nodes.matcher.utils import hamming_distance
             0.45,
             0.00005,
             True,
-            (0.34997, -1),
+            (0.34994000000000003, -1),
         ),
         (
             IrisTemplate(
@@ -154,7 +154,7 @@ from iris.nodes.matcher.utils import hamming_distance
             0.45,
             0.000046,
             True,
-            (0.7251518000000001, 0),
+            (0.7253036, 0),
         ),
         (
             IrisTemplate(
@@ -208,7 +208,7 @@ from iris.nodes.matcher.utils import hamming_distance
             0.45,
             0.00005,
             True,
-            (0.6250645, -1),
+            (0.625129, -1),
         ),
         (
             IrisTemplate(
@@ -226,7 +226,7 @@ from iris.nodes.matcher.utils import hamming_distance
             0.45,
             0.00005,
             True,
-            (0.5041829166666667, 0),
+            (0.5041991666666666, 0),
         ),
         (
             IrisTemplate(
@@ -395,7 +395,7 @@ def test_hamming_distance(
             0.00005,
             True,
             [np.array([[3, 1], [1, 2]]), np.array([[3, 1], [1, 2]])],
-            (0.22486408163265306, 0),
+            (0.22472816326530615, 0),
         ),
         (
             IrisTemplate(
@@ -471,7 +471,7 @@ def test_hamming_distance(
             0.00005,
             True,
             [np.array([[3, 1], [1, 2]]), np.array([[3, 1], [1, 2]])],
-            (0.7251328571428572, 0),
+            (0.7252657142857142, 0),
         ),
         (
             IrisTemplate(
@@ -502,7 +502,7 @@ def test_hamming_distance(
             0.00005,
             True,
             [np.array([[3, 1], [1, 2]]), np.array([[3, 1, 4, 2], [1, 2, 5, 4]])],
-            (0.7251492394655704, 0),
+            (0.7252984789311407, 0),
         ),
     ],
     ids=[


### PR DESCRIPTION
# {{Pull Request name here}}

## PR description

Add option to load weights from a given path, bug fix on half-width matching, the maskbit count should be doubled when applying normalization.

### Issue

When matching is divided to half-width matching (namely, upper and lower eye separately), we need to double the mask bit count so that normalization is not skewed. 

### Solution
<!-- Don't copy Linear ticket description but rather describe the solution. -->

### Limitations
<!-- Document here any known limitation of your implementation. -->

## Type
<!-- Check a proper type with an 'x' ([x]). -->

- [ ] Feature
- [x] Refactoring
- [x] Bugfix
- [ ] DevOps
- [x] Testing

## Checklist
<!-- Please make sure you did all pre review requesting steps and check all with an 'x' ([x]). -->

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
