### PR TITLE
Make sure that `NodeWriterResult` callback is always first in callbacs list of every node.

### DIFF
--- a/src/iris/callbacks/pipeline_trace.py
+++ b/src/iris/callbacks/pipeline_trace.py
@@ -136,7 +136,7 @@ class PipelineCallTraceStorage:
         call_trace = PipelineCallTraceStorage(results_names=nodes.keys())
 
         for algorithm_name, algorithm_object in nodes.items():
-            algorithm_object._callbacks.append(NodeResultsWriter(call_trace, algorithm_name))
+            algorithm_object._callbacks.insert(0, NodeResultsWriter(call_trace, algorithm_name))
 
         return call_trace
 


### PR DESCRIPTION
## PR description

It has to be changed because otherwise result is not saved to call trace whenever validator callback throws an error.

## Type
<!-- Check a proper type with an 'x' ([x]). -->

- [x] Bugfix

## Checklist
<!-- Please make sure you did all pre review requesting steps and check all with an 'x' ([x]). -->

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
