### PR TITLE
fix nondeterministic random generation in multiprocessing

### DIFF
--- a/src/iris/nodes/eye_properties_estimation/bisectors_method.py
+++ b/src/iris/nodes/eye_properties_estimation/bisectors_method.py
@@ -97,12 +97,12 @@ class BisectorsMethod(Algorithm):
         Returns:
             Tuple[np.ndarray, np.ndarray]: Calculated perpendicular bisectors.
         """
-        np.random.seed(142857)
+        rng = np.random.RandomState(142857)
 
         bisectors_first_points = np.empty([0, 2])
         bisectors_second_points = np.empty([0, 2])
         for _ in range(self.params.max_iterations):
-            random_indices = np.random.choice(len(polygon), size=(self.params.num_bisectors, 2))
+            random_indices = rng.choice(len(polygon), size=(self.params.num_bisectors, 2))
 
             first_drawn_points = polygon[random_indices[:, 0]]
             second_drawn_points = polygon[random_indices[:, 1]]


### PR DESCRIPTION
# {{Pull Request name here}}

fix: nondeterministic random generation in multiprocessing due to race conditions on numpy's global random state

Please, give a brief description of what was changed or fixed and how you did it.

### Issue
<!-- Make sure that the problem is explained clearly. -->
 Even though each worker process should have its own state, the timing of when np.random.seed() is called and when random numbers are generated can cause non-deterministic behavior. 

### Solution
<!-- Don't copy Linear ticket description but rather describe the solution. -->
The solution is to use non-global state np.random.generator()to avoid race conditions and generate fully deterministic results with the same seed.

### Limitations
<!-- Document here any known limitation of your implementation. -->

## Type
<!-- Check a proper type with an 'x' ([x]). -->

- [ ] Feature
- [ ] Refactoring
- [x] Bugfix
- [ ] DevOps
- [ ] Testing

## Checklist
<!-- Please make sure you did all pre review requesting steps and check all with an 'x' ([x]). -->

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
