### PR TITLE
fix type of segmap for cv2.resize() as required

### DIFF
--- a/src/iris/nodes/segmentation/multilabel_segmentation_interface.py
+++ b/src/iris/nodes/segmentation/multilabel_segmentation_interface.py
@@ -118,6 +118,6 @@ class MultilabelSemanticSegmentationInterface(Algorithm):
         """
         segmap = np.squeeze(segmap, axis=0)
         segmap = np.transpose(segmap, (1, 2, 0))
-        segmap = cv2.resize(segmap, original_image_resolution, interpolation=cv2.INTER_NEAREST)
+        segmap = cv2.resize(segmap.astype(np.float32), original_image_resolution, interpolation=cv2.INTER_NEAREST)
 
         return segmap


### PR DESCRIPTION
# fix type for cv2.resize() input from segmentation output

## PR description

fix type of input to cv2.resize() as it does not work with float16.

### Issue
<!-- Make sure that the problem is explained clearly. -->
If a segmentation model runs in float16, its output must be converted to float32 before using cv2.resize().

### Solution
<!-- Don't copy Linear ticket description but rather describe the solution. -->

### Limitations
<!-- Document here any known limitation of your implementation. -->

## Type
<!-- Check a proper type with an 'x' ([x]). -->

- [ ] Feature
- [x] Refactoring
- [ ] Bugfix
- [ ] DevOps
- [ ] Testing

## Checklist
<!-- Please make sure you did all pre review requesting steps and check all with an 'x' ([x]). -->

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
