### PR TITLE
16-bits semantic segmentation ONNX model inference support

### DIFF
--- a/src/iris/nodes/segmentation/onnx_multilabel_segmentation.py
+++ b/src/iris/nodes/segmentation/onnx_multilabel_segmentation.py
@@ -85,7 +85,6 @@ class ONNXMultilabelSegmentation(MultilabelSemanticSegmentationInterface):
         if len(model_types) != 1:
             raise ValueError(f"Expected model to have a single data type, but got: {model_types}")
 
-
         super().__init__(
             session=ort.InferenceSession(model_path, providers=["CPUExecutionProvider"]),
             input_resolution=input_resolution,

--- a/tests/unit_tests/pipelines/test_iris_pipeline.py
+++ b/tests/unit_tests/pipelines/test_iris_pipeline.py
@@ -899,13 +899,12 @@ def test_custom_pipeline_without_package_version_uses_parent():
 def test_update_config(config: str, expectation):
     """Test the update_config method with various configurations."""
     pipeline = IRISPipeline()
+    class MockSemSeg:
+        def __init__(self, **kwargs):
+            self._callbacks = []
+
     with expectation:
-        mock_model = MagicMock()
-        mock_model.SerializeToString.return_value = b"dummy_model_data"
-        mock_session = MagicMock(spec=ort.InferenceSession)
-        with patch("onnx.load", return_value=mock_model), patch("onnx.checker.check_model"), patch(
-            "onnxruntime.InferenceSession", return_value=mock_session
-        ):
+        with patch("iris.nodes.segmentation.onnx_multilabel_segmentation.ONNXMultilabelSegmentation", MockSemSeg):
             pipeline.update_config(config)
             if isinstance(expectation, does_not_raise):
                 assert isinstance(pipeline.nodes, dict)


### PR DESCRIPTION
# 16-bits semantic segmentation ONNX model inference support

## PR description

Allow to perform inference if half precision ONNX semantic segmentation models.

## Type
<!-- Check a proper type with an 'x' ([x]). -->

- [x] Feature
- [ ] Refactoring
- [ ] Bugfix
- [ ] DevOps
- [ ] Testing

## Checklist
<!-- Please make sure you did all pre review requesting steps and check all with an 'x' ([x]). -->

- [x] I've made sure that my code works as expected by writing unit tests.
- [x] I've checked if my code doesn't generate warnings or errors.
- [x] I've performed a self-review of my code.
- [x] I've made sure that my code follows the style guidelines of the project.
- [x] I've commented hard-to-understand parts of my code.
- [x] I've made appropriate changes in the documentation.
